### PR TITLE
Update TSNamespace color for NVCode theme

### DIFF
--- a/colors/nvcode.vim
+++ b/colors/nvcode.vim
@@ -100,7 +100,7 @@ hi TSBoolean guifg=#569cd6 ctermfg=74 guibg=NONE ctermbg=NONE gui=NONE cterm=NON
 hi TSFloat guifg=#b5cea8 ctermfg=151 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSAnnotation guifg=#dcdcaa ctermfg=187 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSAttribute guifg=#4ec9b0 ctermfg=79 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
-hi TSNamespace guifg=#ff00ff ctermfg=201 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi TSNamespace guifg=#4ec9b0 ctermfg=79 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSFuncBuiltin guifg=#dcdcaa ctermfg=187 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSFunction guifg=#dcdcaa ctermfg=187 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSFuncMacro guifg=#dcdcaa ctermfg=187 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE

--- a/nvcode.yml
+++ b/nvcode.yml
@@ -130,7 +130,7 @@ highlights:
   TSFloat: "light_green"
   TSAnnotation: "yellow"
   TSAttribute: "cyan"
-  TSNamespace: "#FF00FF"
+  TSNamespace: "cyan"
   # Functions
   TSFuncBuiltin: "yellow"
   TSFunction: "yellow"


### PR DESCRIPTION
The NVCode theme had TSNamespace as #FF00FF (pinkish color), seemingly to be modified later.

TSNamespace is used for the imports in Rust and should be cyan (as it is in VSCode). I thus updated the yaml and ran the generate script.

Thank you for reviewing this PR and letting me know if I missed something.

Keep up the great work!