### PR TITLE
Add color to Conceal for Snazzy

### DIFF
--- a/colors/snazzy.vim
+++ b/colors/snazzy.vim
@@ -43,7 +43,7 @@ hi Cursor guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=reverse cterm=reve
 hi ColorColumn guifg=NONE ctermfg=NONE guibg=#3a3d4d ctermbg=238 gui=NONE cterm=NONE
 hi CursorLineNr guifg=#f1f1f0 ctermfg=255 guibg=NONE ctermbg=NONE gui=bold cterm=bold
 hi SignColumn guifg=NONE ctermfg=NONE guibg=#1e2127 ctermbg=235 gui=NONE cterm=NONE
-hi Conceal guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi Conceal guifg=#606580 ctermfg=60 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi CursorColumn guifg=NONE ctermfg=NONE guibg=#3a3d4d ctermbg=238 gui=NONE cterm=NONE
 hi CursorLine guifg=NONE ctermfg=NONE guibg=#3a3d4d ctermbg=238 gui=NONE cterm=NONE
 hi Directory guifg=#57c7ff ctermfg=81 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE


### PR DESCRIPTION
Conceal color is currently the same as text, which is not desirable.
![Screenshot 2021-02-23 at 15 18 49](https://user-images.githubusercontent.com/12573521/108864784-6f989600-75ea-11eb-8373-14c9d431e74a.png)
Conceal is used by many plugin to show indentLine, so I change it to the same value of `CocExplorerIndentLine`.
![Screenshot 2021-02-23 at 15 19 10](https://user-images.githubusercontent.com/12573521/108864834-7c1cee80-75ea-11eb-9b9b-0f4e8aacb3c2.png)
