### PR TITLE
Add TSKeywordFunction definition to aurora

### DIFF
--- a/aurora.yml
+++ b/aurora.yml
@@ -154,7 +154,7 @@ highlights:
   TSLabel: "light_blue"
   # Does not work for yield and return they should be diff then class and def
   TSKeyword: "blue"
-  TSKeywordFunction: "#FF00FF"
+  TSKeywordFunction: "blue"
   TSKeywordOperator: "blue"
   TSOperator: "white"
   TSException: "purple"

--- a/colors/aurora.vim
+++ b/colors/aurora.vim
@@ -117,7 +117,7 @@ hi TSConditional guifg=#b48ead ctermfg=139 guibg=NONE ctermbg=NONE gui=NONE cter
 hi TSRepeat guifg=#b48ead ctermfg=139 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSLabel guifg=#88c0d0 ctermfg=110 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSKeyword guifg=#5e81ac ctermfg=67 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
-hi TSKeywordFunction guifg=#ff00ff ctermfg=201 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi TSKeywordFunction guifg=#5e81ac ctermfg=67 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSKeywordOperator guifg=#5e81ac ctermfg=67 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSOperator guifg=#d8dee9 ctermfg=254 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSException guifg=#b48ead ctermfg=139 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE


### PR DESCRIPTION
This group is used for the `function` and `end` keywords