### PR TITLE
added VimWiki support

### DIFF
--- a/aurora.yml
+++ b/aurora.yml
@@ -298,3 +298,17 @@ highlights:
   # MoreMsg: "green - br"
   # Question: "cyan - br"
   # Directory: "blue - b"
+  
+  # VimWiki
+  VimwikiHeader1: "orange"
+  VimwikiHeader2: "green"
+  VimwikiHeader3: "blue"
+  VimwikiHeader4: "cyan"
+  VimwikiHeader5: "dark_yellow"
+  VimwikiHeader6: "purple"
+  VimwikiLink: "vivid_blue"
+  VimwikiHeaderChar: "line_grey"
+  VimwikiHR: "yellow"
+  VimwikiList: "orange"
+  VimwikiTag: "orange"
+  VimwikiMarkers: "line_grey"

--- a/colors/aurora.vim
+++ b/colors/aurora.vim
@@ -215,3 +215,15 @@ hi diffNewFile guifg=#a3be8c ctermfg=144 guibg=NONE ctermbg=NONE gui=NONE cterm=
 hi diffOldFile guifg=#bf616a ctermfg=131 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi debugPc guifg=NONE ctermfg=NONE guibg=#8fbcbb ctermbg=109 gui=NONE cterm=NONE
 hi debugBreakpoint guifg=#bf616a ctermfg=131 guibg=NONE ctermbg=NONE gui=reverse cterm=reverse
+hi VimwikiHeader1 guifg=#d08770 ctermfg=173 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader2 guifg=#a3be8c ctermfg=144 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader3 guifg=#5e81ac ctermfg=67 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader4 guifg=#8fbcbb ctermfg=109 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader5 guifg=#d7ba7d ctermfg=180 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader6 guifg=#b48ead ctermfg=139 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiLink guifg=#81a1c1 ctermfg=109 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHeaderChar guifg=#5c6370 ctermfg=241 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHR guifg=#ebcb8b ctermfg=222 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiList guifg=#d08770 ctermfg=173 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiTag guifg=#d08770 ctermfg=173 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiMarkers guifg=#5c6370 ctermfg=241 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE

--- a/colors/dracula.vim
+++ b/colors/dracula.vim
@@ -212,3 +212,15 @@ hi diffNewFile guifg=#50fa7b ctermfg=84 guibg=NONE ctermbg=NONE gui=NONE cterm=N
 hi diffOldFile guifg=#ff5555 ctermfg=203 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi debugPc guifg=NONE ctermfg=NONE guibg=#8be9fd ctermbg=117 gui=NONE cterm=NONE
 hi debugBreakpoint guifg=#ff5555 ctermfg=203 guibg=NONE ctermbg=NONE gui=reverse cterm=reverse
+hi VimwikiHeader1 guifg=#ffb86c ctermfg=215 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader2 guifg=#50fa7b ctermfg=84 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader3 guifg=#ff79c6 ctermfg=212 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader4 guifg=#8be9fd ctermfg=117 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader5 guifg=#f1fa8c ctermfg=228 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader6 guifg=#bd93f9 ctermfg=141 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiLink guifg=#8be9fd ctermfg=117 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHeaderChar guifg=#6272a4 ctermfg=61 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHR guifg=#f1fa8c ctermfg=228 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiList guifg=#ffb86c ctermfg=215 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiTag guifg=#ffb86c ctermfg=215 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiMarkers guifg=#6272a4 ctermfg=61 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE

--- a/colors/gruvbox.vim
+++ b/colors/gruvbox.vim
@@ -227,3 +227,15 @@ hi GitGutterChange guifg=#d79921 ctermfg=172 guibg=NONE ctermbg=NONE gui=NONE ct
 hi GitGutterDelete guifg=#cc241d ctermfg=160 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi debugPc guifg=NONE ctermfg=NONE guibg=#cc241d ctermbg=160 gui=NONE cterm=NONE
 hi debugBreakpoint guifg=#cc241d ctermfg=160 guibg=NONE ctermbg=NONE gui=reverse cterm=reverse
+hi VimwikiHeader1 guifg=#fe8019 ctermfg=208 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader2 guifg=#98971a ctermfg=100 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader3 guifg=#83a598 ctermfg=108 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader4 guifg=#8ec07c ctermfg=108 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader5 guifg=#fb4934 ctermfg=203 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader6 guifg=#d3869b ctermfg=175 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiLink guifg=#689d6a ctermfg=71 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHeaderChar guifg=#504945 ctermfg=239 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHR guifg=#d79921 ctermfg=172 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiList guifg=#d65d0e ctermfg=166 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiTag guifg=#d65d0e ctermfg=166 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiMarkers guifg=#504945 ctermfg=239 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE

--- a/colors/lunar.vim
+++ b/colors/lunar.vim
@@ -266,3 +266,15 @@ hi DashboardHeader guifg=#88c0d0 ctermfg=110 guibg=NONE ctermbg=NONE gui=NONE ct
 hi DashboardCenter guifg=#c68a75 ctermfg=174 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi DashboardFooter guifg=#88c0d0 ctermfg=110 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi WhichKeyFloat guifg=#232731 ctermfg=235 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHeader1 guifg=#c68a75 ctermfg=174 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader2 guifg=#a3be8c ctermfg=144 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader3 guifg=#5e81ac ctermfg=67 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader4 guifg=#88c0d0 ctermfg=110 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader5 guifg=#d7ba7d ctermfg=180 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader6 guifg=#b48ead ctermfg=139 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiLink guifg=#4fc1ff ctermfg=75 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHeaderChar guifg=#5c6370 ctermfg=241 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHR guifg=#e7cb93 ctermfg=186 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiList guifg=#c68a75 ctermfg=174 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiTag guifg=#c68a75 ctermfg=174 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiMarkers guifg=#5c6370 ctermfg=241 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE

--- a/colors/nord.vim
+++ b/colors/nord.vim
@@ -248,3 +248,15 @@ hi LspDiagnosticsUnderlineWarning guifg=#ebcb8b ctermfg=222 guibg=NONE ctermbg=N
 hi LspDiagnosticsUnderlineError guifg=#bf616a ctermfg=131 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi LspDiagnosticsUnderlineInformation guifg=#88c0d0 ctermfg=110 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi LspDiagnosticsUnderlineHint guifg=#5e81ac ctermfg=67 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHeader1 guifg=#d08770 ctermfg=173 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader2 guifg=#a3be8c ctermfg=144 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader3 guifg=#5e81ac ctermfg=67 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader4 guifg=#8fbcbb ctermfg=109 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader5 guifg=#ebcb8b ctermfg=222 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader6 guifg=#b48ead ctermfg=139 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiLink guifg=#88c0d0 ctermfg=110 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHeaderChar guifg=#5c6370 ctermfg=241 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHR guifg=#ebcb8b ctermfg=222 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiList guifg=#d08770 ctermfg=173 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiTag guifg=#d08770 ctermfg=173 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiMarkers guifg=#5c6370 ctermfg=241 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE

--- a/colors/nvcode.vim
+++ b/colors/nvcode.vim
@@ -261,3 +261,15 @@ hi BufferInactiveSign guifg=#858585 ctermfg=102 guibg=#2e2e2e ctermbg=236 gui=NO
 hi BufferInactiveTarget guifg=#d16969 ctermfg=167 guibg=#2e2e2e ctermbg=236 gui=bold cterm=bold
 hi CodiVirtualText guifg=#6395ec ctermfg=69 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi IndentBlanklineContextChar guifg=#707070 ctermfg=242 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHeader1 guifg=#ce9178 ctermfg=174 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader2 guifg=#608b4e ctermfg=65 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader3 guifg=#569cd6 ctermfg=74 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader4 guifg=#4ec9b0 ctermfg=79 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader5 guifg=#d7ba7d ctermfg=180 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader6 guifg=#c586c0 ctermfg=175 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiLink guifg=#4fc1ff ctermfg=75 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHeaderChar guifg=#5c6370 ctermfg=241 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHR guifg=#dcdcaa ctermfg=187 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiList guifg=#ce9178 ctermfg=174 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiTag guifg=#ce9178 ctermfg=174 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiMarkers guifg=#5c6370 ctermfg=241 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE

--- a/colors/onedark.vim
+++ b/colors/onedark.vim
@@ -212,3 +212,15 @@ hi diffNewFile guifg=#98c379 ctermfg=114 guibg=NONE ctermbg=NONE gui=NONE cterm=
 hi diffOldFile guifg=#e06c75 ctermfg=168 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi debugPc guifg=NONE ctermfg=NONE guibg=#56b6c2 ctermbg=73 gui=NONE cterm=NONE
 hi debugBreakpoint guifg=#e06c75 ctermfg=168 guibg=NONE ctermbg=NONE gui=reverse cterm=reverse
+hi VimwikiHeader1 guifg=#d19a66 ctermfg=173 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader2 guifg=#98c379 ctermfg=114 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader3 guifg=#61afef ctermfg=75 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader4 guifg=#56b6c2 ctermfg=73 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader5 guifg=#e5c07b ctermfg=180 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader6 guifg=#c586c0 ctermfg=175 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiLink guifg=#56b6c2 ctermfg=73 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHeaderChar guifg=#5c6370 ctermfg=241 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHR guifg=#e5c07b ctermfg=180 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiList guifg=#d19a66 ctermfg=173 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiTag guifg=#d19a66 ctermfg=173 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiMarkers guifg=#5c6370 ctermfg=241 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE

--- a/colors/palenight.vim
+++ b/colors/palenight.vim
@@ -224,3 +224,15 @@ hi GitGutterChange guifg=#ffcb6b ctermfg=221 guibg=NONE ctermbg=NONE gui=NONE ct
 hi GitGutterDelete guifg=#ff5370 ctermfg=203 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi debugPc guifg=NONE ctermfg=NONE guibg=#89ddff ctermbg=117 gui=NONE cterm=NONE
 hi debugBreakpoint guifg=#ff5370 ctermfg=203 guibg=NONE ctermbg=NONE gui=reverse cterm=reverse
+hi VimwikiHeader1 guifg=#ce9178 ctermfg=174 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader2 guifg=#c3e88d ctermfg=186 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader3 guifg=#82b1ff ctermfg=111 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader4 guifg=#89ddff ctermfg=117 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader5 guifg=#f78c6c ctermfg=209 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader6 guifg=#c792ea ctermfg=176 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiLink guifg=#4fc1ff ctermfg=75 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHeaderChar guifg=#697098 ctermfg=60 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHR guifg=#ffcb6b ctermfg=221 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiList guifg=#ce9178 ctermfg=174 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiTag guifg=#ce9178 ctermfg=174 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiMarkers guifg=#697098 ctermfg=60 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE

--- a/colors/snazzy.vim
+++ b/colors/snazzy.vim
@@ -212,3 +212,15 @@ hi diffNewFile guifg=#5af78e ctermfg=84 guibg=NONE ctermbg=NONE gui=NONE cterm=N
 hi diffOldFile guifg=#ff5c57 ctermfg=203 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi debugPc guifg=NONE ctermfg=NONE guibg=#9aedfe ctermbg=123 gui=NONE cterm=NONE
 hi debugBreakpoint guifg=#ff5c57 ctermfg=203 guibg=NONE ctermbg=NONE gui=reverse cterm=reverse
+hi VimwikiHeader1 guifg=#fbffbd ctermfg=229 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader2 guifg=#5af78e ctermfg=84 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader3 guifg=#57c7ff ctermfg=81 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader4 guifg=#9aedfe ctermfg=123 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader5 guifg=#f3f99d ctermfg=229 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiHeader6 guifg=#ff6ac1 ctermfg=205 guibg=NONE ctermbg=NONE gui=bold cterm=bold
+hi VimwikiLink guifg=#9aedfe ctermfg=123 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHeaderChar guifg=#606580 ctermfg=60 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiHR guifg=#f3f99d ctermfg=229 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiList guifg=#fbffbd ctermfg=229 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiTag guifg=#fbffbd ctermfg=229 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi VimwikiMarkers guifg=#606580 ctermfg=60 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE

--- a/dracula.yml
+++ b/dracula.yml
@@ -287,3 +287,17 @@ highlights:
   # MoreMsg: "green - br"
   # Question: "cyan - br"
   # Directory: "blue - b"
+  
+  # VimWiki
+  VimwikiHeader1: "orange"
+  VimwikiHeader2: "green"
+  VimwikiHeader3: "pink"
+  VimwikiHeader4: "cyan"
+  VimwikiHeader5: "yellow"
+  VimwikiHeader6: "purple"
+  VimwikiLink: "cyan"
+  VimwikiHeaderChar: "line_grey"
+  VimwikiHR: "yellow"
+  VimwikiList: "orange"
+  VimwikiTag: "orange"
+  VimwikiMarkers: "line_grey"

--- a/gruvbox.yml
+++ b/gruvbox.yml
@@ -13,6 +13,7 @@ palette:
   blue: "#458588"
   purple: "#b16286"
   aqua: "#689d6a"
+  orange: "#d65d0e"
   gray: "#a89984"
 
   gray_2: "#928374"
@@ -22,6 +23,7 @@ palette:
   blue_2: "#83a598"
   purple_2: "#d3869b"
   aqua_2: "#8ec07c"
+  orange_2: "#fe8019"
 
   bh0_h: "#1d2021"
   bg0: "#282828"
@@ -29,14 +31,12 @@ palette:
   bg2: "#504945"
   bg3: "#665c54"
   bg4: "#7c6f64"
-  orange: "#d65d0e"
 
   bg0_s: "#32302f"
   fg4: "#a89984"
   fg3: "#bdae93"
   fg2: "#d5c4a1"
   fg1: "#ebdbb2"
-  orange_2: "#fe8019"
 
 highlights:
   Normal: "fg bg"
@@ -312,3 +312,17 @@ highlights:
 
   debugPc: "- red"
   debugBreakpoint: "red - r"
+
+  # VimWiki
+  VimwikiHeader1: "orange_2"
+  VimwikiHeader2: "green"
+  VimwikiHeader3: "blue_2"
+  VimwikiHeader4: "aqua_2"
+  VimwikiHeader5: "red_2"
+  VimwikiHeader6: "purple_2"
+  VimwikiLink: "aqua"
+  VimwikiHeaderChar: "bg2"
+  VimwikiHR: "yellow"
+  VimwikiList: "orange"
+  VimwikiTag: "orange"
+  VimwikiMarkers: "bg2"

--- a/lunar.yml
+++ b/lunar.yml
@@ -397,3 +397,17 @@ highlights:
   # MoreMsg: "green - br"
   # Question: "cyan - br"
   # Directory: "blue - b"
+
+  # VimWiki
+  VimwikiHeader1: "orange"
+  VimwikiHeader2: "green"
+  VimwikiHeader3: "blue"
+  VimwikiHeader4: "cyan"
+  VimwikiHeader5: "dark_yellow"
+  VimwikiHeader6: "purple"
+  VimwikiLink: "vivid_blue"
+  VimwikiHeaderChar: "line_grey"
+  VimwikiHR: "yellow"
+  VimwikiList: "orange"
+  VimwikiTag: "orange"
+  VimwikiMarkers: "line_grey"

--- a/nord.yml
+++ b/nord.yml
@@ -324,3 +324,16 @@ highlights:
   LspDiagnosticsUnderlineInformation: "nord8"
   LspDiagnosticsUnderlineHint: "nord10"
 
+  # VimWiki
+  VimwikiHeader1: "nord12"
+  VimwikiHeader2: "nord14"
+  VimwikiHeader3: "nord10"
+  VimwikiHeader4: "nord7"
+  VimwikiHeader5: "nord13"
+  VimwikiHeader6: "nord15"
+  VimwikiLink: "nord8"
+  VimwikiHeaderChar: "line_grey"
+  VimwikiHR: "nord13"
+  VimwikiList: "nord12"
+  VimwikiTag: "nord12"
+  VimwikiMarkers: "line_grey"

--- a/nvcode.yml
+++ b/nvcode.yml
@@ -376,3 +376,17 @@ highlights:
   # MoreMsg: "green - br"
   # Question: "cyan - br"
   # Directory: "blue - b"
+   
+  # VimWiki
+  VimwikiHeader1: "orange"
+  VimwikiHeader2: "green"
+  VimwikiHeader3: "blue"
+  VimwikiHeader4: "cyan"
+  VimwikiHeader5: "dark_yellow"
+  VimwikiHeader6: "purple"
+  VimwikiLink: "vivid_blue"
+  VimwikiHeaderChar: "line_grey"
+  VimwikiHR: "yellow"
+  VimwikiList: "orange"
+  VimwikiTag: "orange"
+  VimwikiMarkers: "line_grey"

--- a/onedark.yml
+++ b/onedark.yml
@@ -287,3 +287,17 @@ highlights:
   # MoreMsg: "green - br"
   # Question: "cyan - br"
   # Directory: "blue - b"
+  
+  # VimWiki
+  VimwikiHeader1: "orange"
+  VimwikiHeader2: "green"
+  VimwikiHeader3: "blue"
+  VimwikiHeader4: "cyan"
+  VimwikiHeader5: "yellow"
+  VimwikiHeader6: "purple"
+  VimwikiLink: "cyan"
+  VimwikiHeaderChar: "line_grey"
+  VimwikiHR: "yellow"
+  VimwikiList: "orange"
+  VimwikiTag: "orange"
+  VimwikiMarkers: "line_grey"

--- a/palenight.yml
+++ b/palenight.yml
@@ -305,3 +305,17 @@ highlights:
 
   debugPc: "- cyan"
   debugBreakpoint: "red - r"
+  
+  # VimWiki
+  VimwikiHeader1: "orange"
+  VimwikiHeader2: "green"
+  VimwikiHeader3: "blue"
+  VimwikiHeader4: "cyan"
+  VimwikiHeader5: "dark_yellow"
+  VimwikiHeader6: "purple"
+  VimwikiLink: "vivid_blue"
+  VimwikiHeaderChar: "line_grey"
+  VimwikiHR: "yellow"
+  VimwikiList: "orange"
+  VimwikiTag: "orange"
+  VimwikiMarkers: "line_grey"

--- a/snazzy.yml
+++ b/snazzy.yml
@@ -287,3 +287,17 @@ highlights:
     # MoreMsg: "green - br"
     # Question: "cyan - br"
     # Directory: "blue - b"
+  
+    # VimWiki
+    VimwikiHeader1: "orange"
+    VimwikiHeader2: "green"
+    VimwikiHeader3: "blue"
+    VimwikiHeader4: "cyan"
+    VimwikiHeader5: "yellow"
+    VimwikiHeader6: "purple"
+    VimwikiLink: "cyan"
+    VimwikiHeaderChar: "line_grey"
+    VimwikiHR: "yellow"
+    VimwikiList: "orange"
+    VimwikiTag: "orange"
+    VimwikiMarkers: "line_grey"


### PR DESCRIPTION
Added VimWiki support to all the colorschemes available in this repo.

Here is a little example for gruvbox:

### Before
![before](https://user-images.githubusercontent.com/74004229/122261431-eb815b80-cec3-11eb-859a-a84182f29015.png)

### After
![after](https://user-images.githubusercontent.com/74004229/122261455-f4722d00-cec3-11eb-837e-a0f4e1f2218d.png)

Merge this PR if you like it. Thanks for this and LunarVim <3