### PR TITLE
fix(xoria-colorscheme): HTML delimiter and json field colors

### DIFF
--- a/colors/xoria.vim
+++ b/colors/xoria.vim
@@ -112,7 +112,7 @@ hi TSProperty guifg=#dfafdf ctermfg=182 guibg=NONE ctermbg=NONE gui=NONE cterm=N
 hi TSConstructor guifg=#dfafdf ctermfg=182 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSConditional guifg=#afafdf ctermfg=146 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSRepeat guifg=#87afdf ctermfg=110 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
-hi TSLabel guifg=#88c0d0 ctermfg=110 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi TSLabel guifg=#dfafdf ctermfg=182 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSKeyword guifg=#87afdf ctermfg=110 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSKeywordFunction guifg=#afafdf ctermfg=146 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSKeywordOperator guifg=#87afdf ctermfg=110 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
@@ -132,7 +132,7 @@ hi TSTitle guifg=#d0d0d0 ctermfg=252 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSLiteral guifg=#808080 ctermfg=244 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSURI guifg=NONE ctermfg=NONE guibg=NONE ctermbg=NONE gui=underline cterm=underline
 hi TSTag guifg=#87afdf ctermfg=110 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
-hi TSTagDelimiter guifg=#df8787 ctermfg=174 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
+hi TSTagDelimiter guifg=#808080 ctermfg=244 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi TSQueryLinterError guifg=#ffb870 ctermfg=215 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi htmlArg guifg=#dfafdf ctermfg=182 guibg=NONE ctermbg=NONE gui=NONE cterm=NONE
 hi htmlBold guifg=#dfafdf ctermfg=182 guibg=NONE ctermbg=NONE gui=bold cterm=bold

--- a/xoria.yml
+++ b/xoria.yml
@@ -164,7 +164,7 @@ highlights:
   # Keywords
   TSConditional: "gray_blue"
   TSRepeat: "blue"
-  TSLabel: "light_blue"
+  TSLabel: "magenta"
   # Does not work for yield and return they should be diff then class and def
   TSKeyword: "blue"
   TSKeywordFunction: "gray_blue"
@@ -188,7 +188,7 @@ highlights:
   TSURI: "- - u"
   # Tags
   TSTag: "blue"
-  TSTagDelimiter: "red"
+  TSTagDelimiter: "gray"
   TSQueryLinterError: "warning_orange"
   # -- END Treesitter --
 


### PR DESCRIPTION
 - HTML tag delimiter made gray (red was too aggressive)
 - json field changed from blue to magenta to look more
consistent with colorscheme